### PR TITLE
Feat: nginx sidecar

### DIFF
--- a/.github/workflows/build-nginx.yml
+++ b/.github/workflows/build-nginx.yml
@@ -1,0 +1,19 @@
+name: Build Containers
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  cas-nginx-sidecar-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: RafikFarhad/push-to-gcr-github-action@v3.0.2
+        with:
+          gcloud_service_key: ${{ secrets.GCR_KEY }}
+          project_id: ggl-cas-storage
+          image_name: cas-nginx
+          image_tag: latest,${{ github.sha }}
+          dockerfile: nginx-sidecar/Dockerfile
+          context: nginx-sidecar

--- a/.github/workflows/build-nginx.yml
+++ b/.github/workflows/build-nginx.yml
@@ -2,7 +2,8 @@ name: Build Containers
 
 on:
   push:
-    branches: ["**"]
+    branches-ignore:
+      - main
 
 jobs:
   cas-nginx-sidecar-build:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# cas-template-app
-Skeleton app using the Climate Action Secretariat tech stack
+# CAS App Template
+
+A skeleton app that uses the Climate Action Secretariat tech stack
+
+## Utilities
+
+This repository contains various utilities that can be reused:
+
+- An openshift-compatible nginx image, for handling SSL termination in front of various web servers

--- a/nginx-sidecar/Dockerfile
+++ b/nginx-sidecar/Dockerfile
@@ -1,0 +1,15 @@
+FROM nginx:stable-alpine
+
+# support running as arbitrary user which belogs to the root group
+RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx
+RUN chgrp -R root /var/cache/nginx
+
+# users are not allowed to listen on priviliged ports
+RUN sed -i.bak 's/listen\(.*\)80;/listen 8081;/' /etc/nginx/conf.d/default.conf
+EXPOSE 8081
+
+# comment user directive as master process is run as user in OpenShift anyhow
+RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf
+
+RUN addgroup nginx root
+USER nginx


### PR DESCRIPTION
Extracting the nginx sidecar image ( for handling the SSL termination) into this repository, since it'll be reused in different places.
- [x] Dockerfile
- [x] GH action that builds and uploads the image to GCS