### PR TITLE
fix: changing the container name to be unique

### DIFF
--- a/nginx-sidecar/helm/nginx-sidecar/Chart.yaml
+++ b/nginx-sidecar/helm/nginx-sidecar/Chart.yaml
@@ -3,5 +3,5 @@ name: nginx-sidecar
 description: A helm chart that can be used to inject an nginx sidecar pod to handle SSL termination
 
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "1.20.1"

--- a/nginx-sidecar/helm/nginx-sidecar/templates/_deployment-container.yaml
+++ b/nginx-sidecar/helm/nginx-sidecar/templates/_deployment-container.yaml
@@ -9,7 +9,7 @@ It needs to be passed an object that matches the structure of the values of this
 Example: include "nginx-sidecar.deployment-container.tpl" (index .Values "nginx-sidecar")
 */}}
 {{- define "nginx-sidecar.deployment-container.tpl" }}
-- name: "{{ .objectNamePrefix }}"
+- name: "{{ .objectNamePrefix }}"-nginx
   image: "{{ .image.repository }}:{{ .image.tag }}"
   imagePullPolicy: {{ .image.pullPolicy }}
   ports:


### PR DESCRIPTION
the template meant to be injected inside a deployment was generating name collisions