### PR TITLE
Refactor: express middleware stack is called after after auth callback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+exclude: >
+  (?x)^(
+      test\.js\.snap$|
+      stories\.storyshot$
+  )$
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-json
+      - id: check-vcs-permalinks
+      - id: check-yaml
+        exclude: ^helm/.*/templates/
+      - id: end-of-file-fixer
+        exclude: current_version\.txt
+      - id: trailing-whitespace
+        exclude: .*/tests/.*
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v0.12.7
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: (.*/tests/.*|openshift/deploy/secret|Makefile|keycloak-.*-realm-export.json|schema.*)
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.12.0
+    hooks:
+      - id: gitlint

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,59 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2021-11-25T00:38:56Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "StripeDetector"
+    }
+  ],
+  "results": {
+    "packages/sso-react/package.json": [
+      {
+        "hashed_secret": "e01f4256ee2a62993e37c48e8ab105ea9d893e0f",
+        "is_verified": false,
+        "line_number": 65,
+        "type": "Hex High Entropy String"
+      }
+    ]
+  },
+  "version": "0.12.7",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/packages/sso-express/package.json
+++ b/packages/sso-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov-cas/sso-express",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A developer-friendly express middleware to securely connect to OpenId providers",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/sso-express/src/controllers.ts
+++ b/packages/sso-express/src/controllers.ts
@@ -96,13 +96,15 @@ export const loginController =
 
 export const authCallbackController =
   (client: BaseClient, options: SSOExpressOptions) =>
-  async (req: Request, res: Response) => {
+  async (req: Request, res: Response, next: NextFunction) => {
     const state = req.query.state as string;
     const cachedState = req.session.oidcState;
     delete req.session.oidcState;
     if (state !== cachedState) {
       console.log("Invalid OIDC state", state, cachedState);
-      return res.redirect(options.oidcConfig.baseUrl);
+      res.redirect(options.oidcConfig.baseUrl);
+      next();
+      return;
     }
     const callbackParams = client.callbackParams(req);
 
@@ -122,4 +124,6 @@ export const authCallbackController =
       console.error(err);
       res.redirect(options.oidcConfig.baseUrl);
     }
+
+    next();
   };

--- a/packages/sso-express/tests/controllers.test.ts
+++ b/packages/sso-express/tests/controllers.test.ts
@@ -290,12 +290,16 @@ describe("the authCallbackController", () => {
     const res = {
       redirect: jest.fn(),
     } as unknown as Response;
-    await handler(req, res);
+    const next = jest.fn();
+
+    await handler(req, res, next);
+
     expect(req.session.oidcState).toBe(undefined);
     expect(res.redirect).toHaveBeenCalledWith(
       middlewareOptions.oidcConfig.baseUrl
     );
     expect(client.callback).toHaveBeenCalledTimes(0);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it("fetches the tokenSet and redirects to the landing route", async () => {
@@ -309,6 +313,7 @@ describe("the authCallbackController", () => {
     const res = {
       redirect: jest.fn(),
     } as unknown as Response;
+    const next = jest.fn();
 
     const claims = {};
     const callbackParams = {};
@@ -319,7 +324,7 @@ describe("the authCallbackController", () => {
     mocked(client.callback).mockResolvedValue(tokenSet);
     mocked(middlewareOptions.getLandingRoute).mockReturnValue("/landing");
 
-    await handler(req, res);
+    await handler(req, res, next);
 
     expect(req.session.oidcState).toBe(undefined);
     expect(res.redirect).toHaveBeenCalledWith("/landing");
@@ -334,6 +339,7 @@ describe("the authCallbackController", () => {
     );
     expect(req.claims).toBe(claims);
     expect(req.session.tokenSet).toBe(tokenSet);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
   it("redirects to the base URL if it cannot fetch the tokenSet", async () => {
@@ -347,13 +353,14 @@ describe("the authCallbackController", () => {
     const res = {
       redirect: jest.fn(),
     } as unknown as Response;
+    const next = jest.fn();
 
     const callbackParams = {};
 
     mocked(client.callbackParams).mockReturnValue(callbackParams);
     mocked(client.callback).mockRejectedValue(new Error("some-error"));
 
-    await handler(req, res);
+    await handler(req, res, next);
 
     expect(req.session.oidcState).toBe(undefined);
     expect(res.redirect).toHaveBeenCalledWith(
@@ -369,5 +376,6 @@ describe("the authCallbackController", () => {
     );
     expect(req.claims).toBe(undefined);
     expect(req.session.tokenSet).toBe(undefined);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
making sure `next()` is called after the auth callback redirect, to allow the user to add add or customize behaviour through express middlewares.