### PR TITLE
feat: add onAuthCallback option

### DIFF
--- a/packages/sso-express/README.md
+++ b/packages/sso-express/README.md
@@ -42,7 +42,7 @@ const ssoMiddleware = await ssoUtils({
   oidcConfig: {
     oidcIssuer: `https://oidc.gov.bc.ca/auth/realm/myrealm`,
     clientId: "myappresource",
-    clientSecret: 'verysecuresecret', // optional
+    clientSecret: "verysecuresecret", // optional
     baseUrl: "http://localhost:3000",
   },
 });
@@ -87,6 +87,7 @@ In addition, all these configuration keys are accepted:
 | `getLandingRoute`      | Function `(req) => string` used to redirect the user after login.                                                       | `() => '/'`   |
 | `bypassAuthentication` | Set to `true`, `false` or `{ login: t/f , sessionIdleRemainingTime: t/f }` to configure                                 | `false`       |
 | `routes`               | Overrides the default routes below. Set to `false` or `''` to disable (unavailable for login, logout, and authCallback) | see below     |
+| `onAuthCallback`       | Callback function called after the user is authenticated, but before the user is redirected to the landing page.        | `undefined `  |
 
 <br />
 Default routes object:

--- a/packages/sso-express/src/index.ts
+++ b/packages/sso-express/src/index.ts
@@ -65,6 +65,13 @@ export interface SSOExpressOptions {
     sessionIdleRemainingTime?: string;
     authCallback?: string;
   };
+  /**
+   * Callback function called after the user is authenticated,
+   * but before the user is redirected to the landing page.
+   *
+   * @param req The request object, containing req.claims and req.session.tokenSet
+   */
+  onAuthCallback?: (req: Request) => Promise<void> | void;
 }
 
 async function ssoExpress(opts: SSOExpressOptions) {
@@ -91,7 +98,7 @@ async function ssoExpress(opts: SSOExpressOptions) {
     client_secret: clientSecret,
     redirect_uris: [`${baseUrl}${authCallback}`],
     post_logout_redirect_uris: [baseUrl],
-    token_endpoint_auth_method: clientSecret ? 'client_secret_basic' : 'none',
+    token_endpoint_auth_method: clientSecret ? "client_secret_basic" : "none",
   });
 
   // Creating a router middleware on which we'll add all the specific routes and additional middlewares.


### PR DESCRIPTION
BREAKING CHANGE: the next middleware in the stack will not be called after the auth callback. If actions on authentication are needed, onAuthCallback should be used instead