### PR TITLE
feat: allow arbitrary auth url params

### DIFF
--- a/packages/sso-express/README.md
+++ b/packages/sso-express/README.md
@@ -45,6 +45,7 @@ const ssoMiddleware = await ssoUtils({
     clientSecret: "verysecuresecret", // optional
     baseUrl: "http://localhost:3000",
   },
+  authorizationUrlParams: { kc_idp_hint: 'idir' },
 });
 
 server.use(ssoMiddleware);
@@ -81,13 +82,14 @@ const configOptions = {
 
 In addition, all these configuration keys are accepted:
 
-| Key                    | Description                                                                                                             | Default value |
-| :--------------------- | :---------------------------------------------------------------------------------------------------------------------- | :------------ |
-| `applicationDomain`    | Restricts clearing the session cookie to this domain                                                                    | .gov.bc.ca    |
-| `getLandingRoute`      | Function `(req) => string` used to redirect the user after login.                                                       | `() => '/'`   |
-| `bypassAuthentication` | Set to `true`, `false` or `{ login: t/f , sessionIdleRemainingTime: t/f }` to configure                                 | `false`       |
-| `routes`               | Overrides the default routes below. Set to `false` or `''` to disable (unavailable for login, logout, and authCallback) | see below     |
-| `onAuthCallback`       | Callback function called after the user is authenticated, but before the user is redirected to the landing page.        | `undefined `  |
+| Key                     | Description                                                                                                             | Default value |
+| :---------------------  | :---------------------------------------------------------------------------------------------------------------------- | :------------ |
+| `applicationDomain`     | Restricts clearing the session cookie to this domain                                                                    | .gov.bc.ca    |
+| `getLandingRoute`       | Function `(req) => string` used to redirect the user after login.                                                       | `() => '/'`   |
+| `bypassAuthentication`  | Set to `true`, `false` or `{ login: t/f , sessionIdleRemainingTime: t/f }` to configure                                 | `false`       |
+| `routes`                | Overrides the default routes below. Set to `false` or `''` to disable (unavailable for login, logout, and authCallback) | see below     |
+| `onAuthCallback`        | Callback function called after the user is authenticated, but before the user is redirected to the landing page.        | `undefined `  |
+| `authorizationUrlParams`| Additional parameters to be added to the authorization url.                                                             | `undefined `  |
 
 <br />
 Default routes object:

--- a/packages/sso-express/src/controllers.ts
+++ b/packages/sso-express/src/controllers.ts
@@ -96,11 +96,15 @@ export const loginController =
     const codeChallenge = generators.codeChallenge(codeVerifier);
     req.session.codeVerifier = codeVerifier;
 
-    const authUrl = client.authorizationUrl({
+    let authUrl = client.authorizationUrl({
       state,
       code_challenge: codeChallenge,
       code_challenge_method: "S256",
     });
+
+    if (options.authorizationUrlParams) {
+      options.authorizationUrlParams.forEach(param => authUrl += `&${param}`)
+    }
     res.redirect(authUrl);
   };
 

--- a/packages/sso-express/src/controllers.ts
+++ b/packages/sso-express/src/controllers.ts
@@ -100,11 +100,9 @@ export const loginController =
       state,
       code_challenge: codeChallenge,
       code_challenge_method: "S256",
+      ...(options.authorizationUrlParams && { ...options.authorizationUrlParams })
     });
 
-    if (options.authorizationUrlParams) {
-      options.authorizationUrlParams.forEach(param => authUrl += `&${param}`)
-    }
     res.redirect(authUrl);
   };
 

--- a/packages/sso-express/src/controllers.ts
+++ b/packages/sso-express/src/controllers.ts
@@ -109,7 +109,7 @@ export const loginController =
       code_challenge: codeChallenge,
       code_challenge_method: "S256",
       redirect_uri: redirectUri,
-      ...(options.authorizationUrlParams && { ...options.authorizationUrlParams }),
+      ...options.authorizationUrlParams,
     });
 
     res.redirect(authUrl);

--- a/packages/sso-express/src/index.ts
+++ b/packages/sso-express/src/index.ts
@@ -65,7 +65,7 @@ export interface SSOExpressOptions {
     sessionIdleRemainingTime?: string;
     authCallback?: string;
   };
-  authorizationUrlParams?: string[];
+  authorizationUrlParams?: {[key: string]: string};
   /**
    * Callback function called after the user is authenticated,
    * but before the user is redirected to the landing page.

--- a/packages/sso-express/src/index.ts
+++ b/packages/sso-express/src/index.ts
@@ -37,6 +37,7 @@ const defaultOptions: Partial<SSOExpressOptions> = {
     sessionIdleRemainingTime: "/session-idle-remaining-time",
     authCallback: "/auth-callback",
   },
+  authorizationUrlParams: {}
 };
 
 export interface SSOExpressOptions {

--- a/packages/sso-express/src/index.ts
+++ b/packages/sso-express/src/index.ts
@@ -65,6 +65,7 @@ export interface SSOExpressOptions {
     sessionIdleRemainingTime?: string;
     authCallback?: string;
   };
+  authorizationUrlParams?: string[];
   /**
    * Callback function called after the user is authenticated,
    * but before the user is redirected to the landing page.

--- a/packages/sso-express/tests/controllers.test.ts
+++ b/packages/sso-express/tests/controllers.test.ts
@@ -297,12 +297,10 @@ describe("the loginController", () => {
 
   it("adds provided url params to the auth URL", async () => {
     mocked(isAuthenticated).mockReturnValue(false);
-    mocked(client.authorizationUrl).mockReturnValue("https://auth.url/");
     const middlewareOptionsWithURLParams = {
       ...middlewareOptions,
-      authorizationUrlParams: ["url_param_1=value1", "url_param_2=value2"]
+      authorizationUrlParams: { param1: "value1", param2: "value2" }
     }
-
     const handler = loginController(client, middlewareOptionsWithURLParams);
     const req = { session: {} } as Request;
     const res = {
@@ -310,9 +308,15 @@ describe("the loginController", () => {
     } as unknown as Response;
     await handler(req, res);
 
-    expect(res.redirect).toHaveBeenCalledWith("https://auth.url/&url_param_1=value1&url_param_2=value2");
+    expect(client.authorizationUrl).toHaveBeenCalledWith({
+      state: expect.anything(),
+      code_challenge: expect.anything(),
+      code_challenge_method: expect.anything(),
+      param1: 'value1',
+      param2: 'value2',
+    });
+    expect(res.redirect).toHaveBeenCalledWith("https://auth.url");
   });
-
 
 });
 

--- a/packages/sso-express/tests/controllers.test.ts
+++ b/packages/sso-express/tests/controllers.test.ts
@@ -294,6 +294,26 @@ describe("the loginController", () => {
     });
     expect(res.redirect).toHaveBeenCalledWith("https://auth.url");
   });
+
+  it("adds provided url params to the auth URL", async () => {
+    mocked(isAuthenticated).mockReturnValue(false);
+    mocked(client.authorizationUrl).mockReturnValue("https://auth.url/");
+    const middlewareOptionsWithURLParams = {
+      ...middlewareOptions,
+      authorizationUrlParams: ["url_param_1=value1", "url_param_2=value2"]
+    }
+
+    const handler = loginController(client, middlewareOptionsWithURLParams);
+    const req = { session: {} } as Request;
+    const res = {
+      redirect: jest.fn(),
+    } as unknown as Response;
+    await handler(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith("https://auth.url/&url_param_1=value1&url_param_2=value2");
+  });
+
+
 });
 
 describe("the authCallbackController", () => {

--- a/packages/sso-express/tests/controllers.test.ts
+++ b/packages/sso-express/tests/controllers.test.ts
@@ -319,6 +319,9 @@ describe("the loginController", () => {
 
   it("adds provided url params to the auth URL", async () => {
     mocked(isAuthenticated).mockReturnValue(false);
+    const url = new URL("http://example.com/callback");
+    url.searchParams.append("test", "/path/abc");
+    mocked(middlewareOptions.getRedirectUri).mockReturnValueOnce(url);
     const middlewareOptionsWithURLParams = {
       ...middlewareOptions,
       authorizationUrlParams: { param1: "value1", param2: "value2" }
@@ -333,6 +336,7 @@ describe("the loginController", () => {
       state: expect.anything(),
       code_challenge: expect.anything(),
       code_challenge_method: expect.anything(),
+      redirect_uri: expect.anything(),
       param1: 'value1',
       param2: 'value2',
     });


### PR DESCRIPTION
Add optional `authorizationUrlParams` to `SSOExpressOptions` to be added on to the auth URL. 

Card: [305](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/bcgov/cas-cif/305)